### PR TITLE
ci: add QA measures (mypy, bandit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,46 @@ jobs:
       - name: Run flake8
         run: |
           flake8 src/ tests/ --max-line-length=120 --statistics
+
+  type-check:
+    name: type-check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mypy
+          pip install -r requirements.txt
+
+      - name: Run mypy
+        run: |
+          mypy src/ --ignore-missing-imports
+
+  security:
+    name: security
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install bandit
+
+      - name: Run bandit
+        run: |
+          bandit -r src/ -f screen

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ psutil>=5.9.0
 pytest>=7.0.0
 flake8>=6.0.0
 pytest-cov>=4.0.0
+mypy>=1.0.0
+bandit>=1.7.0


### PR DESCRIPTION
## Summary
  - Added mypy static type checking to CI pipeline
  - Added bandit security scanning to CI pipeline                                                                                                                                                                                                                                  
  - Pipeline now has 4 QA measures: pytest, flake8, mypy, bandit
## Resolves
Closes #8