### PR TITLE
ci: add CD pipeline with automated releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,54 @@
+name: CD Pipeline
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build artifact
+        run: |
+          mkdir -p dist
+          cp -r src/ dist/
+          cp config.ini dist/
+          cp requirements.txt dist/
+          echo "${{ github.sha }}" > dist/VERSION
+
+      - name: Generate version tag
+        id: version
+        run: |
+          VERSION="v0.1.$(date +%Y%m%d%H%M%S)"
+          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lf8-monitoring-${{ steps.version.outputs.tag }}
+          path: dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Release ${{ steps.version.outputs.tag }}
+          body: |
+            Automated release from CD pipeline.
+            Commit: ${{ github.sha }}
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
  - Added CD workflow triggered on push to main
  - Automatically builds deployment artifact   
  - Creates GitHub Release with version tag and release notes
## Resolves
Closes #10