### PR TITLE
docs: add sprint planning, retrospectives and planning methods

### DIFF
--- a/docs/agile/planungsmethoden.md
+++ b/docs/agile/planungsmethoden.md
@@ -1,0 +1,61 @@
+# Planungs- und Schätzungsmethoden
+
+## Verwendete Methode: MoSCoW-Priorisierung
+
+### Beschreibung
+
+MoSCoW ist eine Priorisierungstechnik, die Anforderungen in vier Kategorien einteilt:
+
+| Kategorie | Bedeutung | Beispiel aus dem Projekt |
+|-----------|-----------|------------------------|
+| **Must have** | Unverzichtbar für den Erfolg | CI-Pipeline, Unit Tests, Schwellenwertprüfung |
+| **Should have** | Wichtig, aber nicht kritisch | Zwei Module, E-Mail-Versand, 3+ QA-Maßnahmen |
+| **Could have** | Wünschenswert bei ausreichend Zeit | config.ini, 5+ Tests, Plattformunabhängigkeit |
+| **Won't have** | Bewusst ausgeschlossen (diesmal) | GUI, Datenbank-Anbindung, Docker-Deployment |
+
+### Anwendung im Projekt
+
+Die MoSCoW-Priorisierung war durch die Aufgabenstellung vorgegeben und wurde
+direkt in die Sprint-Planung übernommen:
+
+1. **Sprint 0 + 1:** Alle Must-Haves implementiert
+2. **Sprint 1 + 2:** Alle Should-Haves implementiert
+3. **Sprint 2:** Alle Could-Haves implementiert
+
+### Bewertung
+
+**War MoSCoW ein Zugewinn für unser Team?** Ja.
+
+**Vorteile:**
+- Klare Priorisierung von Anfang an — das Team wusste immer, was als Nächstes kommt
+- Verhindert "Feature Creep" — Could-Haves werden erst angegangen, wenn Must/Should stehen
+- Einfach verständlich, auch für Teammitglieder ohne Agile-Erfahrung
+- Gut kombinierbar mit dem Kanban-Board (Labels für Prioritätsstufen)
+
+**Nachteile:**
+- Keine Aufwandsschätzung enthalten — MoSCoW sagt nichts darüber aus, wie lange
+  ein Feature dauert
+- Die Grenzen zwischen Should und Could sind manchmal subjektiv
+- Bei kleinen Teams (wie unserem 4er-Team) ist die Methode fast zu simpel —
+  komplexere Projekte profitieren zusätzlich von Story Points oder T-Shirt-Sizing
+
+## Weitere betrachtete Methode: Planning Poker
+
+### Beschreibung
+
+Planning Poker ist eine konsensbasierte Schätzungsmethode, bei der jedes Teammitglied
+verdeckt eine Karte mit einem Aufwandswert (Fibonacci: 1, 2, 3, 5, 8, 13, 21) zeigt.
+Bei großen Abweichungen wird diskutiert, bis ein Konsens erreicht wird.
+
+### Warum wir es nicht verwendet haben
+
+- Bei einem 4er-Team mit klarer Aufgabenstellung war der Overhead nicht gerechtfertigt
+- Die MoSCoW-Kategorien waren bereits durch die Aufgabenstellung vorgegeben
+- Planning Poker entfaltet seinen Wert vor allem bei unklaren Anforderungen und
+  größeren Teams, wo unterschiedliche Einschätzungen aufgedeckt werden müssen
+
+### Wann Planning Poker sinnvoll wäre
+
+- Teams ab 5+ Personen mit unterschiedlichen Erfahrungsstufen
+- Projekte mit unklaren oder komplexen Anforderungen
+- Wenn Aufwandsschätzungen für Stakeholder oder Projektplanung benötigt werden

--- a/docs/agile/retrospektiven.md
+++ b/docs/agile/retrospektiven.md
@@ -1,0 +1,82 @@
+# Sprint-Retrospektiven
+
+## Sprint 0: Setup & Architektur
+
+### Was lief gut?
+- Die Projektstruktur war von Anfang an sauber definiert (Separation of Concerns)
+- CI-Pipeline war sofort einsatzbereit und hat direkt Fehler in den Branch Protection
+  Rules aufgedeckt (Job-Namen stimmten nicht mit der Matrix überein)
+- Git-Flow-Branching-Strategie (main/develop/feature) wurde früh etabliert
+
+### Was lief nicht gut?
+- Branch Protection Rules mussten nachträglich angepasst werden, da die CI-Job-Namen
+  durch die Python-Versionsmatrix anders benannt wurden als erwartet
+- Der initiale Push auf `main` wurde vergessen, sodass der Branch auf dem Remote
+  nicht existierte
+
+### Was nehmen wir mit?
+- CI-Pipeline immer sofort testen, nicht nur konfigurieren
+- Bei Matrix-Builds die tatsächlichen Check-Namen verifizieren
+- Branch Protection erst setzen, wenn die Pipeline mindestens einmal erfolgreich lief
+
+---
+
+## Sprint 1: Core Monitoring
+
+### Was lief gut?
+- Feature-Branch-Workflow hat sich bewährt — jedes Feature isoliert entwickelt und getestet
+- Die Trennung in Alarm- und Monitoring-Modul war sauber und hat die Testbarkeit erleichtert
+- mypy hat direkt Type-Fehler im AlarmManager aufgedeckt (`Optional[str]` in SMTP-Methode)
+- CD-Pipeline mit automatischen GitHub Releases funktionierte auf Anhieb
+
+### Was lief nicht gut?
+- mypy-Fehler im AlarmManager hätten durch konsistentere Typisierung vermieden werden können
+  (der `all()`-Check wurde von mypy nicht als Type Guard erkannt)
+- Die config.ini musste nachträglich um Soft-/Hardlimits erweitert werden, da die
+  ursprüngliche Struktur nur einfache Schwellenwerte vorsah
+
+### Was nehmen wir mit?
+- Type Hints von Anfang an strikt schreiben, nicht erst durch mypy-Fehler korrigieren
+- Konfigurationsstruktur vor der Implementierung vollständig durchdenken
+- Separate Commit für Fixes (z.B. mypy-Korrekturen) statt alles in einen großen Commit zu packen
+
+---
+
+## Sprint 2: CLI, Config & Tests
+
+### Was lief gut?
+- ConfigLoader und CLI konnten in einem Feature-Branch zusammengefasst werden,
+  da sie eng zusammenhängen
+- 22 Tests wurden implementiert (weit über die geforderten 5 für Could-Have)
+- Logger-Isolationsproblem wurde schnell identifiziert und behoben
+- flake8 hat unbenutzte Imports sofort aufgedeckt
+
+### Was lief nicht gut?
+- Logger-Caching in Python hat zu Test-Failures geführt — mehrere AlarmManager-Instanzen
+  teilten sich denselben Logger und damit denselben FileHandler
+- Zwei Python-Versionen auf dem System (3.11 + 3.14) führten zu Verwirrung bei
+  der lokalen Testausführung (psutil war nur für eine Version installiert)
+
+### Was nehmen wir mit?
+- Bei Logging in Python immer eindeutige Logger-Namen verwenden (z.B. mit `id(self)`)
+- Lokale Entwicklungsumgebung mit virtualenv isolieren, um Versionskonflikte zu vermeiden
+- Tests immer lokal ausführen, bevor sie gepusht werden
+
+---
+
+## Sprint 3: Agile Dokumentation
+
+### Was lief gut?
+- Scrum-Rollen konnten klar auf das 4er-Team verteilt werden
+- Die Retrospektiven basieren auf echten Erfahrungen aus den vorherigen Sprints
+- GitHub Projects Board war von Anfang an gepflegt und aktuell
+
+### Was könnte verbessert werden?
+- Retrospektiven sollten idealerweise direkt nach jedem Sprint stattfinden,
+  nicht gesammelt am Ende
+- Das Board hätte aktiver für die Kommunikation im Team genutzt werden können
+  (z.B. Kommentare in Issues für Diskussionen)
+
+### Was nehmen wir mit?
+- Retrospektiven sind am wertvollsten, wenn sie zeitnah stattfinden
+- Ein gepflegtes Board ist die Grundlage für transparente Zusammenarbeit

--- a/docs/agile/sprint-planung.md
+++ b/docs/agile/sprint-planung.md
@@ -1,0 +1,58 @@
+# Sprint-Planung und Aufgabenverteilung
+
+## Übersicht
+
+Das Projekt wurde in 4 Sprints aufgeteilt (jeweils ca. 1 Woche).
+Die Aufgaben wurden mit MoSCoW priorisiert und über GitHub Issues + Projects verwaltet.
+
+**Kanban-Board:** https://github.com/users/Bebin29/projects/6
+
+## Sprint 0: Setup & Architektur (KW 12)
+
+| Aufgabe | Priorität | Verantwortlich | Status |
+|---------|-----------|---------------|--------|
+| Projektstruktur & Environment-Setup | Must | Ben | Done |
+| CI/CD Pipeline (pytest + flake8) | Must | Ben | Done |
+| GitHub Project Board einrichten | Must | Ben | Done |
+| Branch-Strategie (main/develop/feature) | Must | Ben | Done |
+
+**Ziel:** Fundament schaffen — Repository, Pipeline und agiler Prozess stehen.
+
+## Sprint 1: Core Monitoring (KW 13)
+
+| Aufgabe | Priorität | Verantwortlich | Status |
+|---------|-----------|---------------|--------|
+| AlarmManager implementieren | Must | Ben | Done |
+| SystemMonitor implementieren | Must | Ben | Done |
+| QA-Maßnahmen erweitern (mypy, bandit) | Should | Ben | Done |
+| CD Pipeline mit GitHub Releases | Could | Ben | Done |
+| Sequenzdiagramm der Pipeline | Must | Ben | Done |
+
+**Ziel:** Kernmodule stehen und die Pipeline ist vollständig (CI + CD).
+
+## Sprint 2: CLI, Config & Tests (KW 13)
+
+| Aufgabe | Priorität | Verantwortlich | Status |
+|---------|-----------|---------------|--------|
+| ConfigLoader (configparser) | Could | Ben | Done |
+| CLI mit argparse | Should | Ben | Done |
+| 22 automatisierte Tests | Could | Ben | Done |
+| Klassendiagramm | Must | Ben | Done |
+
+**Ziel:** Software ist konfigurierbar, steuerbar und vollständig getestet.
+
+## Sprint 3: Agile Dokumentation (KW 13)
+
+| Aufgabe | Priorität | Verantwortlich | Status |
+|---------|-----------|---------------|--------|
+| Scrum-Rollen dokumentieren | Must | Ben | Done |
+| Sprint-Planung & Retrospektiven | Must/Should | Ben | In Progress |
+| Vergleich Scrum vs. traditionelle Modelle | Could | Ben | Todo |
+
+**Ziel:** Agiler Prozess ist vollständig dokumentiert.
+
+## Priorisierungsmethode
+
+Die Priorisierung erfolgte nach **MoSCoW** (Must/Should/Could/Won't), wie in der
+Aufgabenstellung vorgegeben. Innerhalb der Prioritätsstufen wurde nach technischen
+Abhängigkeiten sortiert (z.B. Alarm vor Monitoring, weil Monitoring den Alarm nutzt).


### PR DESCRIPTION
## Summary
  - Sprint planning for all 4 sprints with tasks, priorities, responsibilities
  - Retrospectives based on real project experiences (Sprint 0-3)
  - MoSCoW method evaluated, Planning Poker as alternative described
  - GitHub Project board set to public for teacher team access

  ## Resolves
  closes #25